### PR TITLE
[Fixes #3] Manage /etc/resolv.conf as a symlink

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,6 +27,14 @@ class resolvconf::config(
   validate_array($nameservers, $search, $options)
   validate_string($domain)
 
+  include resolvconf::dpkg_reconfigure
+
+  file { '/etc/resolv.conf':
+    ensure => link,
+    target => '../run/resolvconf/resolv.conf',
+    notify => Class['resolvconf::dpkg_reconfigure'],
+  }
+
   file { '/etc/resolvconf/resolv.conf.d/head':
     ensure  => file,
     content => template('resolvconf/etc/resolvconf/resolv.conf.d/head.erb'),

--- a/manifests/dpkg_reconfigure.pp
+++ b/manifests/dpkg_reconfigure.pp
@@ -1,0 +1,14 @@
+# == Class: resolvconf::dpkg_reconfigure
+#
+# Call `dpkg-reconfigure resolvconf` to setup `/run/resolvconf/resolv.conf`.
+#
+# This should be notified after changes to `/etc/resolv.conf`, which should
+# be a symlink to the aforementioned file. If called before it will refuse
+# to run.
+#
+class resolvconf::dpkg_reconfigure {
+  exec { 'dpkg-reconfigure resolvconf':
+    command     => '/usr/sbin/dpkg-reconfigure -f noninteractive resolvconf',
+    refreshonly => true,
+  }
+}

--- a/spec/classes/resolvconf_config_spec.rb
+++ b/spec/classes/resolvconf_config_spec.rb
@@ -14,6 +14,15 @@ describe 'resolvconf' do
   context 'params defaults' do
     let(:params) {{ }}
 
+    it { should include_class('resolvconf::dpkg_reconfigure') }
+
+    it 'should symlink resolv.conf' do
+      should contain_file('/etc/resolv.conf').with(
+        :ensure => 'link',
+        :target => '../run/resolvconf/resolv.conf'
+      )
+    end
+
     it 'should manage head file' do
       should contain_file(file_head).with(
         :ensure  => 'file',

--- a/spec/classes/resolvconf_dpkg_reconfigure_spec.rb
+++ b/spec/classes/resolvconf_dpkg_reconfigure_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'resolvconf::dpkg_reconfigure' do
+  it { should contain_exec('dpkg-reconfigure resolvconf').with(
+    :command     => '/usr/sbin/dpkg-reconfigure -f noninteractive resolvconf',
+    :refreshonly => 'true'
+  )}
+end


### PR DESCRIPTION
This file should be a symlink to the real file that is rendered dynamically
by the resolvconf package. We call out to `dpkg-reconfigure` to ensure that
the target is created correctly, which may not be the case is a machine is
converted to a statically managed `resolv.conf`.

/cc @maxamg @philandstuff @samjsharpe @nickstenning 
