### PR TITLE
[#54433726] Correct resolv.conf symlink for Lucid

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,9 +29,14 @@ class resolvconf::config(
 
   include resolvconf::dpkg_reconfigure
 
+  $resolv_conf_target = $::lsbmajdistrelease ? {
+    /^1[0-1]$/ => '/etc/resolvconf/run/resolv.conf',
+    default     => '../run/resolvconf/resolv.conf',
+  }
+
   file { '/etc/resolv.conf':
     ensure => link,
-    target => '../run/resolvconf/resolv.conf',
+    target => $resolv_conf_target,
     notify => Class['resolvconf::dpkg_reconfigure'],
   }
 

--- a/spec/classes/resolvconf_config_spec.rb
+++ b/spec/classes/resolvconf_config_spec.rb
@@ -16,13 +16,6 @@ describe 'resolvconf' do
 
     it { should include_class('resolvconf::dpkg_reconfigure') }
 
-    it 'should symlink resolv.conf' do
-      should contain_file('/etc/resolv.conf').with(
-        :ensure => 'link',
-        :target => '../run/resolvconf/resolv.conf'
-      )
-    end
-
     it 'should manage head file' do
       should contain_file(file_head).with(
         :ensure  => 'file',
@@ -35,6 +28,34 @@ describe 'resolvconf' do
         :ensure  => 'file',
         :content => ''
       )
+    end
+
+    context 'Ubuntu 10.04' do
+      let(:facts) { default_facts.merge({
+        :lsbdistrelease    => '10.04',
+        :lsbmajdistrelease => '10',
+      })}
+
+      it 'should symlink resolv.conf' do
+        should contain_file('/etc/resolv.conf').with(
+          :ensure => 'link',
+          :target => '/etc/resolvconf/run/resolv.conf'
+        )
+      end
+    end
+
+    context 'Ubuntu 12.04' do
+      let(:facts) { default_facts.merge({
+        :lsbdistrelease    => '12.04',
+        :lsbmajdistrelease => '12',
+      })}
+
+      it 'should symlink resolv.conf' do
+        should contain_file('/etc/resolv.conf').with(
+          :ensure => 'link',
+          :target => '../run/resolvconf/resolv.conf'
+        )
+      end
     end
   end
 


### PR DESCRIPTION
The resolvconf package on Ubuntu Lucid defaults to a `resolv.conf` symlink
target of `/etc/resolvconf/run/resolv.conf`. Not least because it doesn't
have a `/run` dir/mount.

I'm pretty sure this is true of the 11.\* releases too. Though I'm not able
to test.
