### PR TITLE
Support fix in facter 2.2 to lsbmajdistrelease

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -30,7 +30,7 @@ class resolvconf::config(
   include resolvconf::dpkg_reconfigure
 
   $resolv_conf_target = $::lsbmajdistrelease ? {
-    /^1[0-1]$/ => '/etc/resolvconf/run/resolv.conf',
+    /^1[0-1]/ => '/etc/resolvconf/run/resolv.conf',
     default     => '../run/resolvconf/resolv.conf',
   }
 

--- a/spec/classes/resolvconf_config_spec.rb
+++ b/spec/classes/resolvconf_config_spec.rb
@@ -30,7 +30,7 @@ describe 'resolvconf' do
       )
     end
 
-    context 'Ubuntu 10.04' do
+    context 'Ubuntu 10.04 on Facter <= 2.1' do
       let(:facts) { default_facts.merge({
         :lsbdistrelease    => '10.04',
         :lsbmajdistrelease => '10',
@@ -44,10 +44,38 @@ describe 'resolvconf' do
       end
     end
 
-    context 'Ubuntu 12.04' do
+    context 'Ubuntu 10.04' do
+      let(:facts) { default_facts.merge({
+        :lsbdistrelease    => '10.04',
+        :lsbmajdistrelease => '10.04',
+      })}
+
+      it 'should symlink resolv.conf' do
+        should contain_file('/etc/resolv.conf').with(
+          :ensure => 'link',
+          :target => '/etc/resolvconf/run/resolv.conf'
+        )
+      end
+    end
+
+    context 'Ubuntu 12.04 on Facter <= 2.1' do
       let(:facts) { default_facts.merge({
         :lsbdistrelease    => '12.04',
         :lsbmajdistrelease => '12',
+      })}
+
+      it 'should symlink resolv.conf' do
+        should contain_file('/etc/resolv.conf').with(
+          :ensure => 'link',
+          :target => '../run/resolvconf/resolv.conf'
+        )
+      end
+    end
+
+    context 'Ubuntu 12.04' do
+      let(:facts) { default_facts.merge({
+        :lsbdistrelease    => '12.04',
+        :lsbmajdistrelease => '12.04',
       })}
 
       it 'should symlink resolv.conf' do


### PR DESCRIPTION
Facter 2.2 fixed the meaning of lsbmajdistrelease under Ubuntu
(so that e.g. Ubuntu 14.04.1 has lsbmajdistrelease = 14.04 rather
than 14).

To accomodate this fix, this commit changes the version check
to use a slightly looser regex.
