### PR TITLE
Move nameservers from head to tail

### DIFF
--- a/spec/classes/resolvconf_config_spec.rb
+++ b/spec/classes/resolvconf_config_spec.rb
@@ -125,41 +125,13 @@ describe 'resolvconf' do
   context 'resolv.conf.d/head' do
 
     context 'use_local' do
-      context 'false (default) with nameservers' do
-        let(:params) {{
-          :nameservers => ['1.1.1.1'],
-        }}
-
+      context 'false (default)' do
         it { should contain_file(file_head).with_content(
-          /#{file_header}nameserver 1\.1\.1\.1\Z/
+          /#{file_header}\Z/
         )}
       end
 
-      context 'true with nameservers' do
-        let(:params) {{
-          :use_local   => true,
-          :nameservers => ['1.1.1.1'],
-        }}
-
-        it { should contain_file(file_head).with_content(
-          /#{file_header}nameserver 127\.0\.0\.1\nnameserver 1\.1\.1\.1\Z/
-        )}
-      end
-
-      context 'true without nameservers' do
-        let(:params) {{
-          :use_local => true,
-        }}
-
-        it { should contain_file(file_head).with_content(
-          /#{file_header}nameserver 127\.0\.0\.1\Z/
-        )}
-      end
-
-      context 'true, even with dhcp_enabled' do
-        let(:facts) { default_facts.merge({
-          :dhcp_enabled => 'true',
-        })}
+      context 'true' do
         let(:params) {{
           :use_local => true,
         }}
@@ -177,7 +149,9 @@ describe 'resolvconf' do
         it { expect { should }.to raise_error(Puppet::Error, /is not a boolean/) }
       end
     end
+  end
 
+  context 'resolv.conf.d/tail' do
     context 'dhcp_enabled true' do
       let(:facts) { default_facts.merge({
         :dhcp_enabled => 'true',
@@ -188,9 +162,7 @@ describe 'resolvconf' do
           :nameservers => ['1.1.1.1'],
         }}
 
-        it { should contain_file(file_head).with_content(
-          /#{file_header}\Z/
-        )}
+        it { should contain_file(file_tail).with_content('')}
       end
 
       context 'override_dhcp true' do
@@ -199,8 +171,8 @@ describe 'resolvconf' do
           :nameservers   => ['1.1.1.1'],
         }}
 
-        it { should contain_file(file_head).with_content(
-          /#{file_header}nameserver 1\.1\.1\.1\Z/
+        it { should contain_file(file_tail).with_content(
+          /nameserver 1\.1\.1\.1\Z/
         )}
       end
 
@@ -221,7 +193,7 @@ describe 'resolvconf' do
       context 'nameservers => []' do
         let(:params) {{ :nameservers => [] }}
 
-        it { should contain_file(file_head).with_content(/#{file_header}\Z/) }
+        it { should contain_file(file_tail).with_content('') }
       end
 
       context "nameservers => ['1.1.1.1']" do
@@ -229,8 +201,8 @@ describe 'resolvconf' do
           :nameservers => ['1.1.1.1'],
         }}
 
-        it { should contain_file(file_head).with_content(
-          /#{file_header}nameserver 1\.1\.1\.1\Z/
+        it { should contain_file(file_tail).with_content(
+          /nameserver 1\.1\.1\.1\Z/
         )}
       end
 
@@ -239,8 +211,8 @@ describe 'resolvconf' do
           :nameservers => ['1.1.1.1', '2.2.2.2', '3.3.3.3'],
         }}
 
-        it { should contain_file(file_head).with_content(
-          /#{file_header}nameserver 1\.1\.1\.1\nnameserver 2\.2\.2\.2\nnameserver 3\.3\.3\.3\Z/
+        it { should contain_file(file_tail).with_content(
+          /nameserver 1\.1\.1\.1\nnameserver 2\.2\.2\.2\nnameserver 3\.3\.3\.3\Z/
         )}
       end
 
@@ -252,10 +224,6 @@ describe 'resolvconf' do
         it { expect { should }.to raise_error(Puppet::Error, /is not an Array/) }
       end
     end
-
-  end
-
-  context 'resolv.conf.d/tail' do
 
     context 'domain' do
       context 'example.com' do

--- a/templates/etc/resolvconf/resolv.conf.d/head.erb
+++ b/templates/etc/resolvconf/resolv.conf.d/head.erb
@@ -6,12 +6,4 @@ if @use_local
 nameserver 127.0.0.1
 <%
 end
-
-unless @nameservers.empty? or (@dhcp_enabled == 'true' && ! @override_dhcp)
-  @nameservers.each do |ns|
--%>
-nameserver <%= ns %>
-<%
-  end
-end
 -%>

--- a/templates/etc/resolvconf/resolv.conf.d/tail.erb
+++ b/templates/etc/resolvconf/resolv.conf.d/tail.erb
@@ -1,3 +1,12 @@
+<%
+unless @nameservers.empty? or (@dhcp_enabled == 'true' && ! @override_dhcp)
+  @nameservers.each do |ns|
+-%>
+nameserver <%= ns %>
+<%
+  end
+end
+-%>
 <% unless @domain.empty? -%>
 domain <%= @domain %>
 <% end -%>


### PR DESCRIPTION
In #13, @rjw1 mentioned that nameservers should go in tail rather than head.

This commit does that, and updates the tests to reflect their new location.

I've also removed some tests because I don't think there's any need to test the interaction of `use_local` and `nameservers` when they're no longer used in the same place.

Fixes #13.

---

bob, is this what you had in mind? I assumed upstreams were nameservers.