### PR TITLE
Don't use stdlib 5.x until we've tested it.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,6 @@
     }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.0.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
Puppetforge likes bounded ranges for dependencies
so we'll limit stdlib to versions currently published.