### PR TITLE
Change the versions we test with.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ language: ruby
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 rvm:
-  - 1.8.7
   - 1.9.3
 env:
-  matrix:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.8.0"
+  - PUPPET_VERSION="~> 4.9.0"
+matrix:
+  allow_failures:
+  - env: PUPPET_VERSION="~> 4.9.0"


### PR DESCRIPTION
Update the puppet versions, allow Puppet 4 to fail and stop
testing ruby 1.8.7 and puppet 2.7.0