### PR TITLE
Test Puppet 5 under modern ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 ---
-# Verify this with: http://lint.travis-ci.org/
 language: ruby
-# Delete dependency locks for matrix builds.
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
-rvm:
-  - 1.9.3
-env:
-  - PUPPET_VERSION="~> 3.8.0"
-  - PUPPET_VERSION="~> 5.3.0"
 matrix:
+  fast_finish: true
+  include:
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 3.8.0"
+    - rvm: 2.4.0
+      env: PUPPET_VERSION="~> 5.3.0"
   allow_failures:
-  - env: PUPPET_VERSION="~> 5.3.0"
+    - rvm: 2.4.0
+      env: PUPPET_VERSION="~> 5.3.0"


### PR DESCRIPTION
But allow the newer ones to fail as we don't use that.